### PR TITLE
删除清华源镜像，因为其已不再维护anaconda镜像

### DIFF
--- a/chapter1/1.2-pytorch-installation.md
+++ b/chapter1/1.2-pytorch-installation.md
@@ -1,7 +1,7 @@
 # 1.2 Pytorch环境搭建
 PyTorch的安装十分简单，根据[PyTorch官网](https://pytorch.org/)，对系统选择和安装方式等灵活选择即可。
 这里以[anaconda](https://www.anaconda.com/)为例，简单的说一下步骤和要点。
-国内安装anaconda建议使用[清华](https://mirrors.tuna.tsinghua.edu.cn/help/anaconda/)或者[中科大](http://mirrors.ustc.edu.cn/help/anaconda.html)镜像，快的不是一点半点。
+国内安装anaconda建议使用[中科大](http://mirrors.ustc.edu.cn/help/anaconda.html)镜像，快的不是一点半点。
 
 # 1.2.1 安装Pytorch
 anaconda安装完成后可以开始创建环境，这里以win10 系统为例。打开Anaconda Prompt
@@ -34,12 +34,6 @@ conda install pytorch torchvision cudatoolkit=10.0 -c pytorch
 # 目前测试 8.0、9.0、9.1、9.2、10.0都可安装成功
 
 
-```
-需要说明的是如果使用清华的镜像，需要去掉`-c pytorch` 这样才能使用清华源。
-
-使用以下命令添加pytorch的清华源
-```bash
-conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/pytorch/
 ```
 
 验证输入python 进入


### PR DESCRIPTION
根据tuna的公告[close-anaconda-service](https://mirrors4.tuna.tsinghua.edu.cn/news/#close-anaconda-service), tuna将不再维护anaconda的镜像，并且已经关闭了anaconda镜像的入口。所以我删除了tuna的链接和信息，以免使读者困惑。