### PR TITLE
Update 2.1.2-pytorch-basics-autograd.ipynb

### DIFF
--- a/chapter2/2.1.2-pytorch-basics-autograd.ipynb
+++ b/chapter2/2.1.2-pytorch-basics-autograd.ipynb
@@ -46,7 +46,7 @@
     "\n",
     "所以，以后的代码建议直接使用Tensor类进行操作，因为官方文档中已经将Variable设置成过期模块。\n",
     "\n",
-    "要想通过Tensor类本身就支持了使用autograd功能，只需要设置.requries_grad=True\n",
+    "要想通过Tensor类本身就支持了使用autograd功能，只需要设置.requires_grad=True\n",
     "\n",
     "Variable类中的的grad和grad_fn属性已经整合进入了Tensor类中"
    ]


### PR DESCRIPTION
单词拼写错误：
只需要设置.requries_grad=True，这里应该改为只需要设置.requires_grad=True