### PR TITLE
Update 3_neural_networks_tutorial.ipynb

### DIFF
--- a/chapter1/3_neural_networks_tutorial.ipynb
+++ b/chapter1/3_neural_networks_tutorial.ipynb
@@ -92,7 +92,7 @@
     "        x = F.max_pool2d(F.relu(self.conv1(x)), (2, 2))\n",
     "        # If the size is a square you can only specify a single number\n",
     "        x = F.max_pool2d(F.relu(self.conv2(x)), 2)\n",
-    "        x = x.view(-1, self.num_flot_features(x))\n",
+    "        x = x.view(-1, self.num_flat_features(x))\n",
     "        x = F.relu(self.fc1(x))\n",
     "        x = F.relu(self.fc2(x))\n",
     "        x = self.fc3(x)\n",


### PR DESCRIPTION
该类不存在名为num_flot_features的方法，此处应调用名为num_flat_features的方法。